### PR TITLE
Initial implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# MacOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Not all EXR files are supported at the moment. Make sure to check the
 Add the library as a dependency to your project.
 
 ```sh
-go get github.com/mokiat/goexr
+go get github.com/mokiat/goexr/exr@latest
 ```
 
 Parse the image as with any other format. For example:
@@ -23,7 +23,7 @@ import (
 	"image"
 	"os"
 
-	_ "github.com/mokiat/goexr"
+	_ "github.com/mokiat/goexr/exr"
 )
 
 func main() {
@@ -46,7 +46,7 @@ that there is a decoder registered with the `image` package.
 
 ```go
 import (
-  _ "github.com/mokiat/goexr"
+  _ "github.com/mokiat/goexr/exr"
 )
 ```
 
@@ -82,5 +82,5 @@ Supported channel formats:
 At the time of writing, EXR images produced by the following programs appear
 to be supported:
 
-- Krita
-- GIMP
+- [Krita](https://krita.org/)
+- [GIMP](https://www.gimp.org/)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Go library for parsing OpenEXR files.
 
 Not all EXR files are supported at the moment. Make sure to check the
-[Limitations](#Limitations) section.
+[Limitations](#limitations) section.
 
 ## Usage
 
@@ -50,6 +50,8 @@ import (
 )
 ```
 
+For more information check the Go documentation of the `exr` package.
+
 ## Limitations
 
 The library supports a subset of EXR files.
@@ -84,3 +86,58 @@ to be supported:
 
 - [Krita](https://krita.org/)
 - [GIMP](https://www.gimp.org/)
+
+## Tools
+
+Aside from the `exr` package, this library provides two tools that can be used
+to check whether this project works on specific EXR files.
+
+### exrsize
+
+This tool prints the pixel size of an EXR image.
+
+```sh
+exrsize <img.exr>
+```
+
+It can be install as follows:
+
+```sh
+go install github.com/mokiat/goexr/cmd/exrsize@latest
+```
+
+It should work with all version 2 EXR images, even those that cannot be
+decoded by the `exr` package.
+
+### exrtopng
+
+This tool converts an `exr` image into a `png` one by using basic tone mapping
+and gamma correction to convert linear colors into sRGB space.
+
+```sh
+exrtopng <src.exr> <dst.png>
+```
+
+It can be install as follows:
+
+```sh
+go install github.com/mokiat/goexr/cmd/exrtopng@latest
+```
+
+This tool is subject to the above [Limitations](#limitations).
+
+## Resources
+
+For the development of this decoded the following resources were useful:
+
+- [Online Documentation](https://openexr.readthedocs.io/en/latest/TechnicalIntroduction.html)
+
+		Very easy to navigate and contains information on the core concepts.
+
+- [PDF Documentation](https://www.openexr.com/documentation/openexrfilelayout.pdf)
+
+		The Online Documentation appeared to have errors in some places and the PDF variant was useful in such cases.
+
+- [Source Code](https://github.com/AcademySoftwareFoundation/openexr/tree/main/src/lib/OpenEXR)
+
+		Some aspects of OpenEXR are not fully documented and in such cases the only place where answers can be found is the reference implementation. In fact, even the documentation refers to it at times.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,86 @@
 # goexr
-Go library for parsing OpenEXR files
+
+Go library for parsing OpenEXR files.
+
+Not all EXR files are supported at the moment. Make sure to check the
+[Limitations](#Limitations) section.
+
+## Usage
+
+Add the library as a dependency to your project.
+
+```sh
+go get github.com/mokiat/goexr
+```
+
+Parse the image as with any other format. For example:
+
+```go
+package main
+
+import (
+	"fmt"
+	"image"
+	"os"
+
+	_ "github.com/mokiat/goexr"
+)
+
+func main() {
+	file, err := os.Open("example.exr")
+	if err != nil {
+		panic(err)
+	}
+	defer file.Close()
+
+	img, format, err := image.Decode(file)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Bounds [%s]: %v\n", format, img.Bounds())
+}
+```
+
+Make sure that you have added an anonymous import to the library which ensures
+that there is a decoder registered with the `image` package.
+
+```go
+import (
+  _ "github.com/mokiat/goexr"
+)
+```
+
+## Limitations
+
+The library supports a subset of EXR files.
+
+Supported EXR versions:
+
+- `2`
+
+Supported image types:
+
+- `single part scanline`
+
+Supported compression modes:
+
+- `NO_COMPRESSION`
+- `ZIP_COMPRESSION`
+
+Supported channels:
+
+- `R`
+- `G`
+- `B`
+- `A`
+
+Supported channel formats:
+
+- `HALF`
+- `FLOAT`
+
+At the time of writing, EXR images produced by the following programs appear
+to be supported:
+
+- Krita
+- GIMP

--- a/cmd/exrsize/main.go
+++ b/cmd/exrsize/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"image"
+	"log"
+	"os"
+
+	"github.com/mokiat/goexr/exr"
+)
+
+func init() {
+	flag.Usage = func() {
+		cl := flag.CommandLine
+		fmt.Fprintf(cl.Output(), "Usage:\texrsize <source.exr>\n")
+		cl.PrintDefaults()
+	}
+}
+
+func main() {
+	flag.Parse()
+
+	if flag.NArg() != 1 {
+		flag.Usage()
+		os.Exit(1)
+	}
+	source := flag.Arg(0)
+
+	if err := runApp(source); err != nil {
+		log.Printf("Error: %v", err)
+		os.Exit(2)
+	}
+}
+
+func runApp(source string) error {
+	cfg, err := openEXRConfig(source)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%d x %d\n", cfg.Width, cfg.Height)
+	return nil
+}
+
+func openEXRConfig(location string) (image.Config, error) {
+	file, err := os.Open(location)
+	if err != nil {
+		return image.Config{}, fmt.Errorf("error opening file %q: %w", location, err)
+	}
+	defer file.Close()
+
+	cfg, err := exr.DecodeConfig(file)
+	if err != nil {
+		return image.Config{}, fmt.Errorf("error decoding exr image config: %w", err)
+	}
+	return cfg, nil
+}

--- a/cmd/exrtopng/main.go
+++ b/cmd/exrtopng/main.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"image"
+	"image/png"
+	"log"
+	"os"
+
+	"github.com/mokiat/goexr/exr"
+)
+
+func init() {
+	flag.Usage = func() {
+		cl := flag.CommandLine
+		fmt.Fprintf(cl.Output(), "Usage:\texrtopng <source.exr> <target.png>\n")
+		cl.PrintDefaults()
+	}
+}
+
+func main() {
+	flag.Parse()
+
+	if flag.NArg() != 2 {
+		flag.Usage()
+		os.Exit(1)
+	}
+	source, target := flag.Arg(0), flag.Arg(1)
+
+	if err := runApp(source, target); err != nil {
+		log.Printf("Error: %v", err)
+		os.Exit(2)
+	}
+}
+
+func runApp(source, target string) error {
+	img, err := openEXR(source)
+	if err != nil {
+		return err
+	}
+	return savePNG(target, img)
+}
+
+func openEXR(location string) (image.Image, error) {
+	file, err := os.Open(location)
+	if err != nil {
+		return nil, fmt.Errorf("error opening file %q: %w", location, err)
+	}
+	defer file.Close()
+
+	img, err := exr.Decode(file)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding exr image: %w", err)
+	}
+	return img, nil
+}
+
+func savePNG(location string, img image.Image) error {
+	file, err := os.Create(location)
+	if err != nil {
+		return fmt.Errorf("error creating file %q: %w", location, err)
+	}
+	defer file.Close()
+
+	if err := png.Encode(file, img); err != nil {
+		return fmt.Errorf("error encoding png image: %w", err)
+	}
+	return nil
+}

--- a/exr/color.go
+++ b/exr/color.go
@@ -1,0 +1,79 @@
+package exr
+
+import (
+	"image/color"
+	"math"
+)
+
+const (
+	gammaFactor = 1.0 / 2.2
+)
+
+var (
+	// RGBAModel returns the color.Model for RGBAColor colors.
+	RGBAModel color.Model = color.ModelFunc(rgbaModel)
+)
+
+// RGBAColor represents a linear EXR color that implements the color.Color
+// interface and is composed of R, G, B, and A components.
+type RGBAColor struct {
+
+	// R holds the amount of red in this color.
+	R float32
+
+	// G holds the amount of green in this color.
+	G float32
+
+	// B holds the amount of blue in this color.
+	B float32
+
+	// A holds the amount of alpha in this color.
+	A float32
+}
+
+// RGBA returns the alpha-premultiplied red, green, blue and alpha values
+// for the color. Each value ranges within [0, 0xffff], but is represented
+// by a uint32 so that multiplying by a blend factor up to 0xffff will not
+// overflow.
+//
+// An alpha-premultiplied color component c has been scaled by alpha (a),
+// so has valid values 0 <= c <= a.
+//
+// Reinhard tone mapping and gamma correction are performed to convert the
+// color into sRGB space.
+func (c RGBAColor) RGBA() (r, g, b, a uint32) {
+	// tone mapping
+	floatR := float64(c.R / (c.R + 1.0))
+	floatG := float64(c.G / (c.G + 1.0))
+	floatB := float64(c.B / (c.B + 1.0))
+
+	// gamma correction
+	floatR = math.Pow(floatR, gammaFactor)
+	floatG = math.Pow(floatG, gammaFactor)
+	floatB = math.Pow(floatB, gammaFactor)
+
+	// alpha pre-multiplication
+	floatR *= float64(c.A)
+	floatG *= float64(c.A)
+	floatB *= float64(c.A)
+
+	// uint32 conversion
+	r = uint32(floatR*0xFFFF) & 0xFFFF
+	g = uint32(floatG*0xFFFF) & 0xFFFF
+	b = uint32(floatB*0xFFFF) & 0xFFFF
+	a = uint32(c.A*0xFFFF) & 0xFFFF
+	return
+}
+
+func rgbaModel(c color.Color) color.Color {
+	if _, ok := c.(RGBAColor); ok {
+		return c
+	}
+	r, g, b, a := c.RGBA()
+	return RGBAColor{
+		R: float32(r) / float32(0xFFFF),
+		G: float32(g) / float32(0xFFFF),
+		B: float32(b) / float32(0xFFFF),
+		A: float32(a) / float32(0xFFFF),
+	}
+}

--- a/exr/decoder.go
+++ b/exr/decoder.go
@@ -12,6 +12,10 @@ func init() {
 	image.RegisterFormat(exr.Extension, string(exr.MagicSequence[:]), Decode, DecodeConfig)
 }
 
+// DecodeConfig returns the color model and dimensions of an EXR image without
+// decoding the entire image.
+//
+// This function supports all version 2 EXR images.
 func DecodeConfig(in io.Reader) (image.Config, error) {
 	var magic exr.Magic
 	if err := exr.ReadMagic(in, &magic); err != nil {
@@ -41,6 +45,14 @@ func DecodeConfig(in io.Reader) (image.Config, error) {
 	}, nil
 }
 
+// Decode reads an EXR image from in and returns it as an image.Image.
+// The type of the Image is RGBAImage.
+//
+// Only a limited set of EXR image types are supported at the moment.
+// The main restrictions are as follows, though others apply as well:
+//
+// 	- They have to be single-part scan line images.
+// 	- They have to use no compression or zip compression.
 func Decode(in io.Reader) (image.Image, error) {
 	var magic exr.Magic
 	if err := exr.ReadMagic(in, &magic); err != nil {

--- a/exr/decoder.go
+++ b/exr/decoder.go
@@ -1,0 +1,76 @@
+package exr
+
+import (
+	"fmt"
+	"image"
+	"io"
+
+	"github.com/mokiat/goexr/exr/internal/exr"
+)
+
+func init() {
+	image.RegisterFormat(exr.Extension, string(exr.MagicSequence[:]), Decode, DecodeConfig)
+}
+
+func DecodeConfig(in io.Reader) (image.Config, error) {
+	var magic exr.Magic
+	if err := exr.ReadMagic(in, &magic); err != nil {
+		return image.Config{}, fmt.Errorf("error reading magic: %w", err)
+	}
+	if !magic.IsCorrect() {
+		return image.Config{}, fmt.Errorf("incorrect magic sequence \"0x%x\"", magic)
+	}
+
+	var version exr.Version
+	if err := exr.ReadVersion(in, &version); err != nil {
+		return image.Config{}, fmt.Errorf("error reading version: %w", err)
+	}
+	if version.Number() != exr.SupportedVersion {
+		return image.Config{}, fmt.Errorf("unsupported version %d", version.Number())
+	}
+
+	var header exr.Header
+	if err := exr.ReadHeader(in, &header); err != nil {
+		return image.Config{}, fmt.Errorf("error reading header: %w", err)
+	}
+
+	return image.Config{
+		ColorModel: RGBAModel,
+		Width:      int(header.DisplayWindow.Width()),
+		Height:     int(header.DisplayWindow.Height()),
+	}, nil
+}
+
+func Decode(in io.Reader) (image.Image, error) {
+	var magic exr.Magic
+	if err := exr.ReadMagic(in, &magic); err != nil {
+		return nil, fmt.Errorf("error reading magic: %w", err)
+	}
+	if !magic.IsCorrect() {
+		return nil, fmt.Errorf("incorrect magic sequence \"0x%x\"", magic)
+	}
+
+	var version exr.Version
+	if err := exr.ReadVersion(in, &version); err != nil {
+		return nil, fmt.Errorf("error reading version: %w", err)
+	}
+	if version.Number() != exr.SupportedVersion {
+		return nil, fmt.Errorf("unsupported version %d", version.Number())
+	}
+	if version.HasFlag(exr.FlagSingleTile) {
+		return nil, fmt.Errorf("tiled format not supported")
+	}
+	if version.HasFlag(exr.FlagNonImage) {
+		return nil, fmt.Errorf("deep data not supported")
+	}
+	if version.HasFlag(exr.FlagMultipart) {
+		return nil, fmt.Errorf("multipart not supported")
+	}
+
+	var header exr.Header
+	if err := exr.ReadHeader(in, &header); err != nil {
+		return nil, fmt.Errorf("error reading header: %w", err)
+	}
+
+	return nil, fmt.Errorf("TODO")
+}

--- a/exr/doc.go
+++ b/exr/doc.go
@@ -1,0 +1,2 @@
+// Package exr contains an implementation of an OpenEXR image decoder.
+package exr

--- a/exr/image.go
+++ b/exr/image.go
@@ -1,0 +1,46 @@
+package exr
+
+import (
+	"image"
+	"image/color"
+
+	"github.com/mokiat/goexr/exr/internal/exr"
+)
+
+// RGBAImage represents an EXR image that consists of R, G, B, and A components.
+//
+// Even if the original image that is loaded does not contain all of the
+// components, default ones will be assigned.
+type RGBAImage struct {
+	rect     image.Rectangle
+	channelR exr.PixelData
+	channelG exr.PixelData
+	channelB exr.PixelData
+	channelA exr.PixelData
+}
+
+// ColorModel returns the RGBAImage's color model.
+func (i *RGBAImage) ColorModel() color.Model {
+	return RGBAModel
+}
+
+// Bounds returns the domain for which At can return non-zero color.
+// The bounds do not necessarily contain the point (0, 0).
+func (i *RGBAImage) Bounds() image.Rectangle {
+	return i.rect
+}
+
+// At returns the color of the pixel at (x, y).
+// At(Bounds().Min.X, Bounds().Min.Y) returns the upper-left pixel of the grid.
+// At(Bounds().Max.X-1, Bounds().Max.Y-1) returns the lower-right one.
+func (i *RGBAImage) At(x, y int) color.Color {
+	if !(image.Point{x, y}.In(i.rect)) {
+		return RGBAColor{}
+	}
+	return RGBAColor{
+		R: i.channelR.Float32(x, y),
+		G: i.channelG.Float32(x, y),
+		B: i.channelB.Float32(x, y),
+		A: i.channelA.Float32(x, y),
+	}
+}

--- a/exr/image.go
+++ b/exr/image.go
@@ -33,6 +33,9 @@ func (i *RGBAImage) Bounds() image.Rectangle {
 // At returns the color of the pixel at (x, y).
 // At(Bounds().Min.X, Bounds().Min.Y) returns the upper-left pixel of the grid.
 // At(Bounds().Max.X-1, Bounds().Max.Y-1) returns the lower-right one.
+//
+// The returned color is of type RGBAColor which can be used to acquire the
+// linear (float) components of the color.
 func (i *RGBAImage) At(x, y int) color.Color {
 	if !(image.Point{x, y}.In(i.rect)) {
 		return RGBAColor{}

--- a/exr/internal/exr/attribute.go
+++ b/exr/internal/exr/attribute.go
@@ -1,0 +1,35 @@
+package exr
+
+import "io"
+
+func ReadAttributeName(in io.Reader, target *AttributeName) error {
+	return ReadNullTerminatedString(in, target)
+}
+
+const (
+	AttributeNameChannels           AttributeName = "channels"
+	AttributeNameCompression        AttributeName = "compression"
+	AttributeNameDataWindow         AttributeName = "dataWindow"
+	AttributeNameDisplayWindow      AttributeName = "displayWindow"
+	AttributeNameLineOrder          AttributeName = "lineOrder"
+	AttributeNamePixelAspectRatio   AttributeName = "pixelAspectRatio"
+	AttributeNameScreenWindowCenter AttributeName = "screenWindowCenter"
+	AttributeNameScreenWindowWidth  AttributeName = "screenWindowWidth"
+)
+
+type AttributeName string
+
+func ReadAttributeType(in io.Reader, target *AttributeType) error {
+	return ReadNullTerminatedString(in, target)
+}
+
+const (
+	AttributeTypeChannelList AttributeType = "chlist"
+	AttributeTypeCompression AttributeType = "compression"
+	AttributeTypeBox2i       AttributeType = "box2i"
+	AttributeTypeLineOrder   AttributeType = "lineOrder"
+	AttributeTypeFloat       AttributeType = "float"
+	AttributeTypeV2f         AttributeType = "v2f"
+)
+
+type AttributeType string

--- a/exr/internal/exr/box.go
+++ b/exr/internal/exr/box.go
@@ -28,3 +28,11 @@ type Box2i struct {
 	XMax int32
 	YMax int32
 }
+
+func (b Box2i) Width() int32 {
+	return b.XMax - b.XMin + 1
+}
+
+func (b Box2i) Height() int32 {
+	return b.YMax - b.YMin + 1
+}

--- a/exr/internal/exr/box.go
+++ b/exr/internal/exr/box.go
@@ -36,3 +36,10 @@ func (b Box2i) Width() int32 {
 func (b Box2i) Height() int32 {
 	return b.YMax - b.YMin + 1
 }
+
+func (b Box2i) Contains(other Box2i) bool {
+	return other.XMin >= b.XMin &&
+		other.XMax <= b.XMax &&
+		other.YMin >= b.YMin &&
+		other.YMax <= b.YMax
+}

--- a/exr/internal/exr/box.go
+++ b/exr/internal/exr/box.go
@@ -1,0 +1,30 @@
+package exr
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+func ReadBox2i(in io.Reader, target *Box2i) error {
+	if err := binary.Read(in, binary.LittleEndian, &target.XMin); err != nil {
+		return fmt.Errorf("error reading min x: %w", err)
+	}
+	if err := binary.Read(in, binary.LittleEndian, &target.YMin); err != nil {
+		return fmt.Errorf("error reading min y: %w", err)
+	}
+	if err := binary.Read(in, binary.LittleEndian, &target.XMax); err != nil {
+		return fmt.Errorf("error reading max x: %w", err)
+	}
+	if err := binary.Read(in, binary.LittleEndian, &target.YMax); err != nil {
+		return fmt.Errorf("error reading max y: %w", err)
+	}
+	return nil
+}
+
+type Box2i struct {
+	XMin int32
+	YMin int32
+	XMax int32
+	YMax int32
+}

--- a/exr/internal/exr/channel.go
+++ b/exr/internal/exr/channel.go
@@ -1,0 +1,69 @@
+package exr
+
+import (
+	"fmt"
+	"io"
+)
+
+func ReadChannelList(in io.Reader, target *ChannelList) error {
+	var channels []Channel
+	for {
+		var channel Channel
+		if err := ReadNullTerminatedString(in, &channel.Name); err != nil {
+			return fmt.Errorf("error reading channel name: %w", err)
+		}
+		if channel.Name == "" {
+			break
+		}
+		if err := Read(in, &channel.PixelType); err != nil {
+			return fmt.Errorf("error reading channel pixel type: %w", err)
+		}
+		if err := Read(in, &channel.Linear); err != nil {
+			return fmt.Errorf("error reading channel linearity: %w", err)
+		}
+		var reserved [3]int8
+		if err := Read(in, &reserved); err != nil {
+			return fmt.Errorf("error reading channel reserved data: %w", err)
+		}
+		if err := Read(in, &channel.XSampling); err != nil {
+			return fmt.Errorf("error reading channel x sampling: %w", err)
+		}
+		if err := Read(in, &channel.YSampling); err != nil {
+			return fmt.Errorf("error reading channel y sampling: %w", err)
+		}
+		channels = append(channels, channel)
+	}
+	*target = ChannelList(channels)
+	return nil
+}
+
+type ChannelList []Channel
+
+type Channel struct {
+	Name      string
+	PixelType PixelType
+	Linear    bool
+	XSampling int32
+	YSampling int32
+}
+
+const (
+	PixelTypeUint  PixelType = 0
+	PixelTypeHalf  PixelType = 1
+	PixelTypeFloat PixelType = 2
+)
+
+type PixelType int32
+
+func (t PixelType) String() string {
+	switch t {
+	case PixelTypeUint:
+		return "uint"
+	case PixelTypeHalf:
+		return "half"
+	case PixelTypeFloat:
+		return "float"
+	default:
+		return fmt.Sprintf("unknown(%d)", t)
+	}
+}

--- a/exr/internal/exr/channel.go
+++ b/exr/internal/exr/channel.go
@@ -58,12 +58,12 @@ type PixelType int32
 func (t PixelType) String() string {
 	switch t {
 	case PixelTypeUint:
-		return "uint"
+		return "UINT"
 	case PixelTypeHalf:
-		return "half"
+		return "HALF"
 	case PixelTypeFloat:
-		return "float"
+		return "FLOAT"
 	default:
-		return fmt.Sprintf("unknown(%d)", t)
+		return fmt.Sprintf("UNKNOWN(%d)", t)
 	}
 }

--- a/exr/internal/exr/chunk.go
+++ b/exr/internal/exr/chunk.go
@@ -1,0 +1,26 @@
+package exr
+
+import (
+	"fmt"
+	"io"
+)
+
+func ChunkCount(dataWindow Box2i, compression Compression) int {
+	lineCount := compression.LineCount()
+	return (int(dataWindow.YMax-dataWindow.YMin) + lineCount) / lineCount
+}
+
+func ReadOffsets(in io.Reader, chunkCount int) error {
+	var lastOffset uint64
+	for i := 0; i < chunkCount; i++ {
+		var offset uint64
+		if err := Read(in, &offset); err != nil {
+			return fmt.Errorf("error reading offset: %w", err)
+		}
+		if offset < lastOffset {
+			return fmt.Errorf("non-incrementing chunk offsets")
+		}
+		lastOffset = offset
+	}
+	return nil
+}

--- a/exr/internal/exr/compression.go
+++ b/exr/internal/exr/compression.go
@@ -1,0 +1,69 @@
+package exr
+
+import (
+	"fmt"
+	"io"
+)
+
+func ReadCompression(in io.Reader, target *Compression) error {
+	return Read(in, target)
+}
+
+const (
+	CompressionNone  Compression = 0
+	CompressionRLE   Compression = 1
+	CompressionZIPS  Compression = 2
+	CompressionZIP   Compression = 3
+	CompressionPIZ   Compression = 4
+	CompressionPXR24 Compression = 5
+	CompressionB44   Compression = 6
+	CompressionB44A  Compression = 7
+)
+
+type Compression uint8
+
+func (c Compression) LineCount() int {
+	switch c {
+	case CompressionNone:
+		return 1
+	case CompressionRLE:
+		return 1
+	case CompressionZIPS:
+		return 1
+	case CompressionZIP:
+		return 16
+	case CompressionPIZ:
+		return 32
+	case CompressionPXR24:
+		return 16
+	case CompressionB44:
+		return 32
+	case CompressionB44A:
+		return 32
+	default:
+		panic(fmt.Errorf("unknown compression type %d", c))
+	}
+}
+
+func (c Compression) String() string {
+	switch c {
+	case CompressionNone:
+		return "NONE"
+	case CompressionRLE:
+		return "RLE"
+	case CompressionZIPS:
+		return "ZIPS"
+	case CompressionZIP:
+		return "ZIP"
+	case CompressionPIZ:
+		return "PIZ"
+	case CompressionPXR24:
+		return "PXR24"
+	case CompressionB44:
+		return "B44"
+	case CompressionB44A:
+		return "B44A"
+	default:
+		return fmt.Sprintf("unknown(%d)", c)
+	}
+}

--- a/exr/internal/exr/compression.go
+++ b/exr/internal/exr/compression.go
@@ -64,6 +64,6 @@ func (c Compression) String() string {
 	case CompressionB44A:
 		return "B44A"
 	default:
-		return fmt.Sprintf("unknown(%d)", c)
+		return fmt.Sprintf("UNKNOWN(%d)", c)
 	}
 }

--- a/exr/internal/exr/decompressor.go
+++ b/exr/internal/exr/decompressor.go
@@ -1,0 +1,69 @@
+package exr
+
+import (
+	"bytes"
+	"compress/zlib"
+	"io"
+)
+
+type Decompressor interface {
+	Decompress(src *bytes.Buffer) (*bytes.Buffer, error)
+}
+
+func NewNopDecompressor() Decompressor {
+	return &nopDecompressor{}
+}
+
+type nopDecompressor struct{}
+
+func (d *nopDecompressor) Decompress(src *bytes.Buffer) (*bytes.Buffer, error) {
+	return src, nil
+}
+
+func NewZipDecompressor() Decompressor {
+	return &zipDecompressor{}
+}
+
+type zipDecompressor struct{}
+
+func (d *zipDecompressor) Decompress(src *bytes.Buffer) (*bytes.Buffer, error) {
+	zlibIn, err := zlib.NewReader(src)
+	if err != nil {
+		return nil, err
+	}
+	out := &bytes.Buffer{}
+	if _, err := io.Copy(out, zlibIn); err != nil {
+		return nil, err
+	}
+	if err := zlibIn.Close(); err != nil {
+		return nil, err
+	}
+
+	data := out.Bytes()
+
+	// reconstruct scalar
+	for i := 1; i < len(data); i++ {
+		v := int(data[i-1]) + int(data[i]) - 128
+		data[i] = byte(v)
+	}
+
+	// interleave scalar
+	result := make([]byte, len(data))
+	i1 := 0
+	i2 := (len(data) + 1) / 2
+	j := 0
+	for j < len(result) {
+		result[j] = data[i1]
+		j++
+		i1++
+
+		if j >= len(result) {
+			break
+		}
+		result[j] = data[i2]
+		j++
+		i2++
+	}
+
+	return bytes.NewBuffer(result), nil
+}

--- a/exr/internal/exr/header.go
+++ b/exr/internal/exr/header.go
@@ -1,0 +1,87 @@
+package exr
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+)
+
+func ReadHeader(in io.Reader, target *Header) error {
+	for {
+		var attributeName AttributeName
+		if err := ReadAttributeName(in, &attributeName); err != nil {
+			return fmt.Errorf("error reading attribute name: %w", err)
+		}
+		if attributeName == "" {
+			return nil
+		}
+
+		var attributeType AttributeType
+		if err := ReadAttributeType(in, &attributeType); err != nil {
+			return fmt.Errorf("error reading attribute type: %w", err)
+		}
+
+		var attributeSize int32
+		if err := Read(in, &attributeSize); err != nil {
+			return fmt.Errorf("error reading attribute size: %w", err)
+		}
+
+		attributeValue := make([]byte, attributeSize)
+		if err := Read(in, &attributeValue); err != nil {
+			return fmt.Errorf("error reading attribute value: %w", err)
+		}
+
+		switch attributeName {
+		case AttributeNameChannels:
+			if attributeType != AttributeTypeChannelList {
+				return fmt.Errorf("incorrect channels attribute type %q", attributeType)
+			}
+			if err := ReadChannelList(bytes.NewReader(attributeValue), &target.Channels); err != nil {
+				return fmt.Errorf("error reading channels: %w", err)
+			}
+
+		case AttributeNameCompression:
+			if attributeType != AttributeTypeCompression {
+				return fmt.Errorf("incorrect compression attribute type %q", attributeType)
+			}
+			if err := ReadCompression(bytes.NewReader(attributeValue), &target.Compression); err != nil {
+				return fmt.Errorf("error reading compression: %w", err)
+			}
+
+		case AttributeNameDataWindow:
+			if attributeType != AttributeTypeBox2i {
+				return fmt.Errorf("incorrect data window attribute type %q", attributeType)
+			}
+			if err := ReadBox2i(bytes.NewReader(attributeValue), &target.DataWindow); err != nil {
+				return fmt.Errorf("error reading data window: %w", err)
+			}
+
+		case AttributeNameDisplayWindow:
+			if attributeType != AttributeTypeBox2i {
+				return fmt.Errorf("incorrect display window attribute type %q", attributeType)
+			}
+			if err := ReadBox2i(bytes.NewReader(attributeValue), &target.DisplayWindow); err != nil {
+				return fmt.Errorf("error reading display window: %w", err)
+			}
+
+		case AttributeNameLineOrder:
+			if attributeType != AttributeTypeLineOrder {
+				return fmt.Errorf("incorrect line order attribute type %q", attributeType)
+			}
+			if err := ReadLineOrder(bytes.NewReader(attributeValue), &target.LineOrder); err != nil {
+				return fmt.Errorf("error reading line order: %w", err)
+			}
+
+		default:
+			// Skip unknown / unnecessary attributes
+		}
+	}
+}
+
+type Header struct {
+	Channels      ChannelList
+	Compression   Compression
+	DataWindow    Box2i
+	DisplayWindow Box2i
+	LineOrder     LineOrder
+}

--- a/exr/internal/exr/io.go
+++ b/exr/internal/exr/io.go
@@ -13,7 +13,7 @@ func Read(in io.Reader, data any) error {
 	return binary.Read(in, order, data)
 }
 
-func ReadNullTerminatedString(in io.Reader, target *string) error {
+func ReadNullTerminatedString[T ~string](in io.Reader, target *T) error {
 	var buffer []byte
 	for {
 		var char byte
@@ -25,6 +25,6 @@ func ReadNullTerminatedString(in io.Reader, target *string) error {
 		}
 		buffer = append(buffer, char)
 	}
-	*target = string(buffer)
+	*target = T(buffer)
 	return nil
 }

--- a/exr/internal/exr/io.go
+++ b/exr/internal/exr/io.go
@@ -1,0 +1,30 @@
+package exr
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+var (
+	order = binary.LittleEndian
+)
+
+func Read(in io.Reader, data any) error {
+	return binary.Read(in, order, data)
+}
+
+func ReadNullTerminatedString(in io.Reader, target *string) error {
+	var buffer []byte
+	for {
+		var char byte
+		if err := Read(in, &char); err != nil {
+			return err
+		}
+		if char == 0x00 {
+			break
+		}
+		buffer = append(buffer, char)
+	}
+	*target = string(buffer)
+	return nil
+}

--- a/exr/internal/exr/line_order.go
+++ b/exr/internal/exr/line_order.go
@@ -1,0 +1,31 @@
+package exr
+
+import (
+	"fmt"
+	"io"
+)
+
+func ReadLineOrder(in io.Reader, target *LineOrder) error {
+	return Read(in, target)
+}
+
+const (
+	LineOrderIncreasingY LineOrder = 0
+	LineOrderDecreasingY LineOrder = 1
+	LineOrderRandomY     LineOrder = 2
+)
+
+type LineOrder uint8
+
+func (o LineOrder) String() string {
+	switch o {
+	case LineOrderIncreasingY:
+		return "INCREASING_Y"
+	case LineOrderDecreasingY:
+		return "DECREASING_Y"
+	case LineOrderRandomY:
+		return "RANDOM_Y"
+	default:
+		return fmt.Sprintf("UNKNOWN(%d)", o)
+	}
+}

--- a/exr/internal/exr/magic.go
+++ b/exr/internal/exr/magic.go
@@ -1,0 +1,23 @@
+package exr
+
+import (
+	"io"
+)
+
+const (
+	Extension = "exr"
+)
+
+var (
+	MagicSequence = [4]byte{0x76, 0x2F, 0x31, 0x01}
+)
+
+func ReadMagic(in io.Reader, target *Magic) error {
+	return Read(in, target)
+}
+
+type Magic [4]byte
+
+func (m Magic) IsCorrect() bool {
+	return m == MagicSequence
+}

--- a/exr/internal/exr/pixel_data.go
+++ b/exr/internal/exr/pixel_data.go
@@ -1,0 +1,74 @@
+package exr
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/x448/float16"
+)
+
+type PixelData interface {
+	ReadLine(in io.Reader, y int32) error
+	Float32(x, y int) float32
+}
+
+func NewNopPixelData(value float32) PixelData {
+	return &nopPixelData{
+		value: value,
+	}
+}
+
+type nopPixelData struct {
+	value float32
+}
+
+func (d *nopPixelData) ReadLine(in io.Reader, y int32) error {
+	return fmt.Errorf("cannot read into nop pixel data")
+}
+
+func (d *nopPixelData) Float32(x, y int) float32 {
+	return d.value
+}
+
+func NewFloat16PixelData(window Box2i, xSampling, ySampling int32) PixelData {
+	width := window.Width() / xSampling
+	height := window.Height() / ySampling
+	return &float16PixelData{
+		window:    window,
+		xSampling: xSampling,
+		ySampling: ySampling,
+		pixels:    make([]float16.Float16, width*height),
+	}
+}
+
+type float16PixelData struct {
+	window    Box2i
+	xSampling int32
+	ySampling int32
+	pixels    []float16.Float16
+}
+
+func (d *float16PixelData) ReadLine(in io.Reader, y int32) error {
+	width := d.window.Width() / d.xSampling
+	y = (y - d.window.YMin) / d.ySampling
+	offset := y * width
+	if err := Read(in, d.pixels[offset:offset+width:offset+width]); err != nil {
+		return fmt.Errorf("error reading pixel slice: %w", err)
+	}
+	return nil
+}
+
+func (d *float16PixelData) Float32(x, y int) float32 {
+	offX := (int32(x) - d.window.XMin) / d.xSampling
+	offY := (int32(y) - d.window.YMin) / d.ySampling
+	width := d.window.Width() / d.xSampling
+
+	value := d.pixels[offX+width*offY]
+	if value.IsInf(0) {
+		value = float16.Frombits(uint16(0x7bff)) // max value
+	}
+	if value.IsNaN() {
+		value = float16.Frombits(uint16(0x0000)) // min value
+	}
+	return value.Float32()
+}

--- a/exr/internal/exr/pixel_data.go
+++ b/exr/internal/exr/pixel_data.go
@@ -8,6 +8,7 @@ import (
 )
 
 type PixelData interface {
+	LineSize() int32
 	ReadLine(in io.Reader, y int32) error
 	Float32(x, y int) float32
 }
@@ -22,12 +23,41 @@ type nopPixelData struct {
 	value float32
 }
 
+func (d *nopPixelData) LineSize() int32 {
+	return 0
+}
+
 func (d *nopPixelData) ReadLine(in io.Reader, y int32) error {
 	return fmt.Errorf("cannot read into nop pixel data")
 }
 
 func (d *nopPixelData) Float32(x, y int) float32 {
 	return d.value
+}
+
+func NewUint32PixelData(window Box2i, xSampling, ySampling int32) PixelData {
+	return &uint32PixelData{
+		width: window.Width() / xSampling,
+	}
+}
+
+type uint32PixelData struct {
+	width int32
+}
+
+func (d *uint32PixelData) LineSize() int32 {
+	return d.width * 4
+}
+
+func (d *uint32PixelData) ReadLine(in io.Reader, y int32) error {
+	if _, err := io.CopyN(io.Discard, in, int64(d.width)*4); err != nil {
+		return fmt.Errorf("error reading uint32 pixel slice: %w", err)
+	}
+	return nil
+}
+
+func (d *uint32PixelData) Float32(x, y int) float32 {
+	return 0.0 // uint32 is used for object reference, not colors
 }
 
 func NewFloat16PixelData(window Box2i, xSampling, ySampling int32) PixelData {
@@ -48,12 +78,17 @@ type float16PixelData struct {
 	pixels    []float16.Float16
 }
 
+func (d *float16PixelData) LineSize() int32 {
+	width := d.window.Width() / d.xSampling
+	return width * 2
+}
+
 func (d *float16PixelData) ReadLine(in io.Reader, y int32) error {
 	width := d.window.Width() / d.xSampling
 	y = (y - d.window.YMin) / d.ySampling
 	offset := y * width
 	if err := Read(in, d.pixels[offset:offset+width:offset+width]); err != nil {
-		return fmt.Errorf("error reading pixel slice: %w", err)
+		return fmt.Errorf("error reading float16 pixel slice: %w", err)
 	}
 	return nil
 }
@@ -71,4 +106,44 @@ func (d *float16PixelData) Float32(x, y int) float32 {
 		value = float16.Frombits(uint16(0x0000)) // min value
 	}
 	return value.Float32()
+}
+
+func NewFloat32PixelData(window Box2i, xSampling, ySampling int32) PixelData {
+	width := window.Width() / xSampling
+	height := window.Height() / ySampling
+	return &float32PixelData{
+		window:    window,
+		xSampling: xSampling,
+		ySampling: ySampling,
+		pixels:    make([]float32, width*height),
+	}
+}
+
+type float32PixelData struct {
+	window    Box2i
+	xSampling int32
+	ySampling int32
+	pixels    []float32
+}
+
+func (d *float32PixelData) LineSize() int32 {
+	width := d.window.Width() / d.xSampling
+	return width * 4
+}
+
+func (d *float32PixelData) ReadLine(in io.Reader, y int32) error {
+	width := d.window.Width() / d.xSampling
+	y = (y - d.window.YMin) / d.ySampling
+	offset := y * width
+	if err := Read(in, d.pixels[offset:offset+width:offset+width]); err != nil {
+		return fmt.Errorf("error reading float32 pixel slice: %w", err)
+	}
+	return nil
+}
+
+func (d *float32PixelData) Float32(x, y int) float32 {
+	offX := (int32(x) - d.window.XMin) / d.xSampling
+	offY := (int32(y) - d.window.YMin) / d.ySampling
+	width := d.window.Width() / d.xSampling
+	return d.pixels[offX+width*offY]
 }

--- a/exr/internal/exr/scanline.go
+++ b/exr/internal/exr/scanline.go
@@ -1,0 +1,54 @@
+package exr
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+)
+
+func ReadScanLineBlock(in io.Reader, dataWindow Box2i, compression Compression, decompressor Decompressor, dataChannels []PixelData) error {
+	var yCoordinate int32
+	if err := Read(in, &yCoordinate); err != nil {
+		return fmt.Errorf("error reading block y coordinate: %w", err)
+	}
+
+	var dataSize int32
+	if err := Read(in, &dataSize); err != nil {
+		return fmt.Errorf("error reading block data size: %w", err)
+	}
+
+	buffer := &bytes.Buffer{}
+	if _, err := io.CopyN(buffer, in, int64(dataSize)); err != nil {
+		return fmt.Errorf("error reading block data: %w", err)
+	}
+
+	blockHeight := int32(compression.LineCount())
+	if dataWindow.YMax-yCoordinate+1 < blockHeight {
+		blockHeight = dataWindow.YMax - yCoordinate + 1
+	}
+
+	if compression == CompressionZIP {
+		uncompressedSize := int32(0)
+		for _, dataChannel := range dataChannels {
+			uncompressedSize += dataChannel.LineSize()
+		}
+		uncompressedSize *= blockHeight
+
+		if uncompressedSize > dataSize {
+			var err error
+			buffer, err = decompressor.Decompress(buffer)
+			if err != nil {
+				return fmt.Errorf("error decompressing block data: %w", err)
+			}
+		}
+	}
+
+	for y := yCoordinate; y < yCoordinate+blockHeight; y++ {
+		for _, dataChannel := range dataChannels {
+			if err := dataChannel.ReadLine(buffer, y); err != nil {
+				return fmt.Errorf("error reading scan line: %w", err)
+			}
+		}
+	}
+	return nil
+}

--- a/exr/internal/exr/version.go
+++ b/exr/internal/exr/version.go
@@ -1,0 +1,30 @@
+package exr
+
+import "io"
+
+const (
+	SupportedVersion = 2
+)
+
+func ReadVersion(in io.Reader, target *Version) error {
+	return Read(in, target)
+}
+
+type Version int32
+
+func (v Version) Number() int {
+	return int(v & 0xFF)
+}
+
+func (v Version) HasFlag(flag Flag) bool {
+	return int32(v)&int32(flag) == int32(flag)
+}
+
+type Flag int32
+
+const (
+	FlagSingleTile Flag = 1 << 8  // one at 9-th bit in version
+	FlagLongName   Flag = 1 << 9  // one at 10-th bit in version
+	FlagNonImage   Flag = 1 << 10 // one at 11-th bit in version
+	FlagMultipart  Flag = 1 << 11 // one at 12-th bit in version
+)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/mokiat/goexr
+
+go 1.18
+
+require github.com/x448/float16 v0.8.4

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=


### PR DESCRIPTION
This PR adds a superficial initial implementation of an OpenEXR (`exr`) decoder in Go.

Things that are missing in this iteration but should probably be added in next ones:
- Performance should be improved (there is a lot of unnecessary allocation)
- More compression modes should be supported (at least `PIZ` should be considered)
- Tests should be added
